### PR TITLE
Update scanner configuration to be loadable from properties as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,24 @@ Implement the design mentioned here: https://excalidraw.com/#room=fba0103fa26425
 
 ## Setup
 
-### Set config properties:<br/>
+### Set config properties:
  
-In order to provide configuration to this application, you would need to export the below environment variables:
-- SNYK_ORG_ID=orgid
-- SNYK_TOKEN=token
+In order to provide configuration to this application, you would need to modify the 
+[`application.properties`](src/main/resources/application.properties) file, or export the following environment variables:
+
+- SCANNER_OSSINDEX_ENABLED=true
 - SCANNER_OSSINDEX_API_USERNAME=username
 - SCANNER_OSSINDEX_API_TOKEN=token
-- CACHE_VALIDITY=token
-- SNYK_ENABLED=true
-- OSS_ENABLED=true
+- SCANNER_SNYK_ENABLED=true
+- SCANNER_SNYK_ORG_ID=orgid
+- SCANNER_SNYK_TOKEN=token
+- SCANNER_CACHE_VALIDITY_PERIOD=6666
+
+> **Note**
+> The OSS Index analyzer is enabled per default for unauthenticated use.
+
+Refer to the [Quarkus Configuration Reference](https://quarkus.io/guides/config-reference#configuration-sources) 
+for more information about available configuration sources and the order in which they're loaded.
 
 ### Verify if Cwe store contains values
 

--- a/src/main/java/org/acme/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/acme/tasks/scanners/OssIndexAnalysisTask.java
@@ -75,17 +75,20 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements S
     @Inject
     OssIndexParser parser;
 
-    private String apiUsername;
-    private String apiToken;
+    private final String apiUsername;
+    private final String apiToken;
 
-    private boolean ossEnabled;
+    private final boolean ossEnabled;
 
     @Inject
-    public OssIndexAnalysisTask(@ConfigProperty(name = "SCANNER_OSSINDEX_API_USERNAME") String apiUsername, @ConfigProperty(name = "SCANNER_OSSINDEX_API_TOKEN") String apiToken, @ConfigProperty(name = "CACHE_VALIDITY") String cacheValidity, @ConfigProperty(name = "OSS_ENABLED") String enabled) {
+    public OssIndexAnalysisTask(@ConfigProperty(name = "scanner.ossindex.api.username") Optional<String> apiUsername,
+                                @ConfigProperty(name = "scanner.ossindex.api.token") Optional<String> apiToken,
+                                @ConfigProperty(name = "scanner.cache.validity.period") String cacheValidity,
+                                @ConfigProperty(name = "scanner.ossindex.enabled") Optional<Boolean> enabled){
         super.cacheValidityPeriod = Long.parseLong(cacheValidity);
-        this.apiUsername = apiUsername;
-        this.apiToken = apiToken;
-        this.ossEnabled = enabled.equalsIgnoreCase("true");
+        this.apiUsername = apiUsername.orElse(null);
+        this.apiToken = apiToken.orElse(null);
+        this.ossEnabled = enabled.orElse(false);
     }
 
     public AnalyzerIdentity getAnalyzerIdentity() {

--- a/src/main/java/org/acme/tasks/scanners/SnykAnalysisTask.java
+++ b/src/main/java/org/acme/tasks/scanners/SnykAnalysisTask.java
@@ -73,11 +73,14 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subsc
     }
 
     @Inject
-    public SnykAnalysisTask(@ConfigProperty(name = "SNYK_ORG_ID") String orgId, @ConfigProperty(name = "SNYK_TOKEN") String snykToken, @ConfigProperty(name = "CACHE_VALIDITY") String cacheValidity, @ConfigProperty(name = "SNYK_ENABLED") String isEnabled) {
-        super.cacheValidityPeriod = Long.parseLong(cacheValidity);
-        this.orgId = orgId;
-        this.snykToken = "token " + snykToken;
-        this.snykEnabled = isEnabled.equalsIgnoreCase("true");
+    public SnykAnalysisTask(@ConfigProperty(name = "scanner.snyk.org.id") Optional<String> orgId,
+                            @ConfigProperty(name = "scanner.snyk.token") Optional<String> snykToken,
+                            @ConfigProperty(name = "scanner.cache.validity.period") long cacheValidity,
+                            @ConfigProperty(name = "scanner.snyk.enabled") Optional<Boolean> isEnabled) {
+        super.cacheValidityPeriod = cacheValidity;
+        this.orgId = orgId.orElse(null);
+        this.snykToken = snykToken.map(token -> "token " + token).orElse(null);
+        this.snykEnabled = isEnabled.orElse(false);
     }
 
     public SnykAnalysisTask() {
@@ -88,7 +91,7 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subsc
      * {@inheritDoc}
      */
     public void inform(final Event e) {
-        if(this.snykEnabled){
+        if(this.snykEnabled && this.orgId != null && this.snykToken != null){
             API_BASE_URL = "https://api.snyk.io/rest/orgs/" + this.orgId + "/packages/";
             Instant start = Instant.now();
             SnykAnalysisEvent event = (SnykAnalysisEvent) e;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,4 +44,18 @@ poc.consumer-batch-size-snyk=500
 poc.consumer-batch-size-oss=128
 
 
+## Scanner Configuration
+#
+scanner.cache.validity.period=864000
 
+## OSS Index Configuration
+#
+scanner.ossindex.enabled=true
+#scanner.ossindex.api.username=
+#scanner.ossindex.api.token=
+
+## Snyk Configuration
+#
+#scanner.snyk.enabled=
+#scanner.snyk.org.id=
+#scanner.snyk.token=


### PR DESCRIPTION
Passing them via env variables is still possible, see https://quarkus.io/guides/config-reference#environment-variables

Also handle optional values, so it's not required to provide all properties anymore.

Signed-off-by: nscuro <nscuro@protonmail.com>