### PR TITLE
Fix and improve OSS Index analyzer

### DIFF
--- a/src/main/java/org/acme/consumer/OSSIndexBatcher.java
+++ b/src/main/java/org/acme/consumer/OSSIndexBatcher.java
@@ -1,34 +1,47 @@
 package org.acme.consumer;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import io.quarkus.kafka.client.serialization.ObjectMapperSerde;
-
 import io.quarkus.runtime.StartupEvent;
 import org.acme.common.ApplicationProperty;
 import org.acme.event.OssIndexAnalysisEvent;
 import org.acme.model.Component;
+import org.acme.model.VulnerablityResult;
 import org.acme.serde.ArrayListDeserializer;
 import org.acme.serde.ArrayListSerializer;
+import org.acme.serde.VulnerabilityResultDeserializer;
+import org.acme.serde.VulnerabilityResultSerializer;
+import org.acme.tasks.scanners.AnalyzerIdentity;
 import org.acme.tasks.scanners.OssIndexAnalysisTask;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
-import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.state.WindowStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Properties;
 
 @ApplicationScoped
 public class OSSIndexBatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OSSIndexBatcher.class);
+
     KafkaStreams streams;
 
     @Inject
@@ -51,20 +64,43 @@ public class OSSIndexBatcher {
         ObjectMapperSerde<Component> componentSerde = new ObjectMapperSerde<>(Component.class);
 
         KStream<String, Component> kStreams = streamsBuilder.stream(applicationProperty.analysisTopic(), Consumed.with(Serdes.String(), componentSerde));
-        KTable<Windowed<String>, ArrayList<Component>> a = kStreams.groupByKey().windowedBy(tumblingWindow)
-                .aggregate(ArrayList::new, (k, v, aggr) -> {
-                            aggr.add(v);
-                            return aggr;
-                        }, Materialized.<String, ArrayList<Component>, WindowStore<Bytes, byte[]>>
-                                        as(applicationProperty.ossStoreName())
-                                .withKeySerde(Serdes.String())
-                                .withValueSerde(Serdes.serdeFrom(new ArrayListSerializer(), new ArrayListDeserializer()))//Custom Serdes
+        kStreams.split()
+                // For components that cannot be analyzed with OSS Index, report "no vulnerabilities"
+                // immediately. This provides a faster feedback compared to waiting for the windowed
+                // aggregation to complete first.
+                .branch(
+                        (k, v) -> v.isInternal() || v.getPurl() == null,
+                        Branched.withConsumer(ks -> ks
+                                .map((k, v) -> {
+                                    final var result = new VulnerablityResult();
+                                    result.setIdentity(AnalyzerIdentity.OSSINDEX_ANALYZER);
+                                    result.setVulnerability(null);
+                                    return new KeyValue<>(v.getUuid(), result);
+                                })
+                                .to(applicationProperty.topicVulnCacheResult(), Produced.with(Serdes.UUID(),
+                                        Serdes.serdeFrom(new VulnerabilityResultSerializer(), new VulnerabilityResultDeserializer())))
+                        )
+                )
+                .branch(
+                        (k, v) -> true,
+                        Branched.withConsumer(ks -> ks
+                                .groupByKey().windowedBy(tumblingWindow)
+                                .aggregate(ArrayList::new, (k, v, aggr) -> {
+                                            aggr.add(v);
+                                            return aggr;
+                                        }, Materialized.<String, ArrayList<Component>, WindowStore<Bytes, byte[]>>
+                                                        as(applicationProperty.ossStoreName())
+                                                .withKeySerde(Serdes.String())
+                                                .withValueSerde(Serdes.serdeFrom(new ArrayListSerializer(), new ArrayListDeserializer()))//Custom Serdes
+                                )
+                                .toStream()
+                                .foreach((stringWindowed, components) -> {
+                                    OssIndexAnalysisEvent ossIndexAnalysisEvent = new OssIndexAnalysisEvent();
+                                    ossIndexAnalysisEvent.setComponents(components);
+                                    task.inform(ossIndexAnalysisEvent);
+                                })
+                        )
                 );
-        a.toStream().foreach((stringWindowed, components) -> {
-            OssIndexAnalysisEvent ossIndexAnalysisEvent = new OssIndexAnalysisEvent();
-            ossIndexAnalysisEvent.setComponents(components);
-            task.inform(ossIndexAnalysisEvent);
-        });
 
         streams = new KafkaStreams(streamsBuilder.build(), props);
         streams.start();

--- a/src/main/java/org/acme/tasks/scanners/BaseComponentAnalyzerTask.java
+++ b/src/main/java/org/acme/tasks/scanners/BaseComponentAnalyzerTask.java
@@ -138,17 +138,24 @@ public abstract class BaseComponentAnalyzerTask implements ScanTask {
             if (jsonResult != null) {
                 final JsonArray vulns = jsonResult.getJsonArray("vulnIds");
                 if (vulns != null) {
-                    for (JsonNumber vulnId : vulns.getValuesAs(JsonNumber.class)) {
-                        final Vulnerability vulnerability = vulnCacheReader.getVulnCache(vulnId.longValue());
+                    if (vulns.isEmpty()) {
+                        final var vulnerablityResult = new VulnerablityResult();
+                        vulnerablityResult.setIdentity(analyzerIdentity);
+                        vulnerablityResult.setVulnerability(null);
+                        vulnerabilityResultProducer.sendVulnResultToDT(component.getUuid(), vulnerablityResult);
+                    } else {
+                        for (JsonNumber vulnId : vulns.getValuesAs(JsonNumber.class)) {
+                            final Vulnerability vulnerability = vulnCacheReader.getVulnCache(vulnId.longValue());
                             /*final Component c = qm.getObjectByUuid(Component.class, component.getUuid());
                             if (c == null) continue;*/
-                        if (vulnerability != null) {
-                            //NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component);
-                            final var vulnerablityResult = new VulnerablityResult();
-                            vulnerablityResult.setIdentity(analyzerIdentity);
-                            vulnerablityResult.setVulnerability(vulnerability);
-                            vulnerabilityResultProducer.sendVulnResultToDT(component.getUuid(), vulnerablityResult);
+                            if (vulnerability != null) {
+                                //NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component);
+                                final var vulnerablityResult = new VulnerablityResult();
+                                vulnerablityResult.setIdentity(analyzerIdentity);
+                                vulnerablityResult.setVulnerability(vulnerability);
+                                vulnerabilityResultProducer.sendVulnResultToDT(component.getUuid(), vulnerablityResult);
 
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
* Emit a `VulnerabilityResult` with `vulnerability=null` when no vulnerabilities have been found
* Emit and cache all reported vulnerabilities, not only one
* Fix caching by setting the `id` field of the generated `Vulnerability`
* Cache results even when no vulnerabilities have been reported by OSS Index