### PR TITLE
Fix kafka dev ui on quarkus dev services

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 quarkus.http.port=8089
 
 ## Kafka
-#
+kafka.bootstrap.servers=localhost:9092
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.application-id=dtrack-vuln-analyzer
 quarkus.kafka-streams.application-server=localhost:8089


### PR DESCRIPTION
added kafka.bootstrap.servers=localhost:9092 property to enable kafka dev ui to work

Signed-off-by: mehab <meha.bhargava2@gmail.com>
<img width="1508" alt="Screenshot 2022-11-04 at 18 53 59" src="https://user-images.githubusercontent.com/26340948/200053452-862b47fb-052d-4de2-bc9c-dc8f363adefc.png">
