### PR TITLE
Clarify key of `component-analysis` topic

### DIFF
--- a/src/main/java/org/acme/consumer/AnalyzerTopology.java
+++ b/src/main/java/org/acme/consumer/AnalyzerTopology.java
@@ -79,7 +79,7 @@ public class AnalyzerTopology {
                         .withName("consume_component-analysis_topic"))
                 .peek((uuid, component) -> LOGGER.info("Received component: {}", component),
                         Named.as("log_components"))
-                .flatMap((projectUuid, component) -> {
+                .flatMap((uuid, component) -> {
                     final var components = new ArrayList<KeyValue<String, Component>>();
                     if (component.getCpe() != null) {
                         // TODO: Canonicalize the CPE used as key, so that CPEs describing the same component end up in the same partition.


### PR DESCRIPTION
We do not use the project UUID anymore, but instead the component UUID.

Signed-off-by: nscuro <nscuro@protonmail.com>