### PR TITLE
Fix repo meta analyzer

### DIFF
--- a/commons/src/main/resources/alpine.version
+++ b/commons/src/main/resources/alpine.version
@@ -1,0 +1,7 @@
+# This file is required when Alpine's Config class is used.
+# Content does not matter, it will be logged to STDOUT whenever
+# the Config class is first accessed.
+name=Alpine
+version=X.X.X
+timestamp=2022-11-11
+uuid=bfc108f4-dfce-4ae7-b291-6b9725fab2fc

--- a/commons/src/main/resources/application.version
+++ b/commons/src/main/resources/application.version
@@ -1,0 +1,7 @@
+# This file is required when Alpine's Config class is used.
+# Content does not matter, it will be logged to STDOUT whenever
+# the Config class is first accessed.
+name=repository-meta-analyzer
+version=X.X.X
+timestamp=2022-11-11
+uuid=fc92227e-ead2-4010-b949-17c080719506

--- a/repository-meta-analyzer/src/main/java/org/acme/repositories/MavenMetaAnalyzer.java
+++ b/repository-meta-analyzer/src/main/java/org/acme/repositories/MavenMetaAnalyzer.java
@@ -80,11 +80,9 @@ public class MavenMetaAnalyzer extends AbstractMetaAnalyzer {
         final MetaModel meta = new MetaModel(component);
         if (component.getPurl() != null) {
             final String mavenGavUrl = component.getPurl().getNamespace().replaceAll("\\.", "/") + "/" + component.getPurl().getName();
-            URIBuilder builder = new URIBuilder();
-            builder.setHost(baseUrl);
-            builder.setPath(REPO_METADATA_URL + '/' + mavenGavUrl);
+            final String url = String.format(baseUrl + REPO_METADATA_URL, mavenGavUrl);
             try {
-                final HttpUriRequest request = new HttpGet(builder.toString());
+                final HttpUriRequest request = new HttpGet(url);
 
                 if (username != null || password != null) {
                     request.setHeader("Authorization", HttpUtil.basicAuthHeaderValue(username, password));
@@ -115,7 +113,7 @@ public class MavenMetaAnalyzer extends AbstractMetaAnalyzer {
                             }
                         }
                     } else {
-                        handleUnexpectedHttpResponse(LOGGER, builder.toString(), status.getStatusCode(), status.getReasonPhrase(), component);
+                        handleUnexpectedHttpResponse(LOGGER, url, status.getStatusCode(), status.getReasonPhrase(), component);
                     }
                 }
             } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {


### PR DESCRIPTION
The app would fail because the analyzers still use the pooled HTTP client, which rely on Alpine's `Config` for initialization.

Initialization of `Config` would fail because neither `alpine.version` nor `application.version` were on the classpath, causing `NullPointerException`s when the `Config` class was first accessed. 

Also the URL building of the Maven analyzer was broken.