### PR TITLE
Add JaCoCo

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>quarkus-junit5-mockito</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -76,6 +81,11 @@
       <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>quarkus-flyway</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.pebbletemplates</groupId>
@@ -65,6 +70,11 @@
       <plugin>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
     <quarkus.platform.version>2.14.2.Final</quarkus.platform.version>
 
+    <!-- Plugin Versions -->
+    <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
+
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
@@ -207,6 +210,25 @@
                   <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 </systemPropertyVariables>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${plugin.jacoco.version}</version>
+          <executions>
+            <execution>
+              <id>default-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+              <configuration>
+                <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
+                <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                <append>true</append>
               </configuration>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
 
     <!-- SonarCloud -->
-    <sonar.coverage.jacoco.xmlReportPaths>./vulnerability-analyzer/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>**/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
 
     <!-- SonarCloud -->
-    <sonar.coverage.jacoco.xmlReportPaths>**/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>./vulnerability-analyzer/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
     <!-- Plugin Versions -->
     <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
 
+    <!-- SonarCloud -->
+    <sonar.coverage.jacoco.xmlReportPaths>**/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
@@ -229,6 +232,18 @@
                 <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
                 <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
                 <append>true</append>
+              </configuration>
+            </execution>
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <dataFile>${project.build.directory}/jacoco-quarkus.exec</dataFile>
+                <formats>
+                  <format>XML</format>
+                </formats>
               </configuration>
             </execution>
           </executions>

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>quarkus-flyway</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -56,6 +61,11 @@
       <plugin>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>quarkus-flyway</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>us.springett</groupId>
@@ -93,6 +98,11 @@
       <plugin>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We need to use the `quarkus-jacoco` extension, as well as the vanilla `jacoco-maven-plugin` in order for all test classes to be accounted for, not just those annotated with `@QuarkusTest`: https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest

Not sure if SonarCloud can pick up the non-XML formatted report though.

Signed-off-by: nscuro <nscuro@protonmail.com>