### PR TITLE
Fix erroneous removal of jacoco plugins

### DIFF
--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -87,6 +87,11 @@
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -65,11 +65,6 @@
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.apache.kafka</groupId>
-          <artifactId>kafka-streams-test-utils</artifactId>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
 
   <build>
@@ -77,6 +72,11 @@
       <plugin>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Also remove duplicate dependency of `kafka-streams-test-utils` in repo meta analyzer POM

Signed-off-by: nscuro <nscuro@protonmail.com>