### PR TITLE
Revert "Update actions/setup-java action to v3.7.0 (#143)"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v3
       
     - name: Set up JDK
-      uses: actions/setup-java@v3.7.0
+      uses: actions/setup-java@v3.6.0
       with:
         distribution: 'temurin'
         java-version: '17'


### PR DESCRIPTION
Builds are failing due to https://github.com/actions/setup-java/issues/422