### PR TITLE
Downgrade dependency io.pebbletemplates:pebble to v3.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <lib.maven-artifact.version>4.0.0-alpha-3</lib.maven-artifact.version>
     <lib.mockserver-netty.version>5.14.0</lib.mockserver-netty.version>
     <lib.packageurl-java.version>1.4.1</lib.packageurl-java.version>
-    <lib.pebble.version>3.2.0</lib.pebble.version>
+    <lib.pebble.version>3.1.6</lib.pebble.version>
     <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
     <lib.unirest.version>3.14.1</lib.unirest.version>
     <lib.wiremock.version>2.35.0</lib.wiremock.version>


### PR DESCRIPTION
Downgrade dependency io.pebbletemplates:pebble to v3.1.6