### PR TITLE
Fix "No serializer found for class" exceptions when running as native image

### DIFF
--- a/commons/src/main/java/org/acme/common/ApacheCommonsLoggingReflectionConfiguration.java
+++ b/commons/src/main/java/org/acme/common/ApacheCommonsLoggingReflectionConfiguration.java
@@ -1,0 +1,22 @@
+package org.acme.common;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.impl.LogFactoryImpl;
+import org.apache.commons.logging.impl.SimpleLog;
+
+/**
+ * Register classes of Apache Commons Logging for reflection.
+ * <p>
+ * Fixes {@link ClassNotFoundException} when running as native image.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/issues/10128">Quarkus issue #10128</a>
+ */
+@SuppressWarnings("unused")
+@RegisterForReflection(targets = {
+        LogFactory.class,
+        LogFactoryImpl.class,
+        SimpleLog.class
+})
+public class ApacheCommonsLoggingReflectionConfiguration {
+}

--- a/commons/src/main/java/org/acme/model/AnalyzersConfig.java
+++ b/commons/src/main/java/org/acme/model/AnalyzersConfig.java
@@ -1,6 +1,9 @@
 package org.acme.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.io.Serializable;
 
+@RegisterForReflection
 public record AnalyzersConfig(boolean snykEnabled, boolean OSSEnabled, boolean internalAnalyzerEnabled) implements Serializable {
 }

--- a/commons/src/main/java/org/acme/model/Component.java
+++ b/commons/src/main/java/org/acme/model/Component.java
@@ -21,7 +21,6 @@ package org.acme.model;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -29,19 +28,17 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.google.gson.JsonObject;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.acme.common.TrimmedStringDeserializer;
 import org.acme.persistence.UUIDConverter;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -55,6 +52,7 @@ import java.util.UUID;
  * @since 3.0.0
  */
 @Entity
+@RegisterForReflection
 @Table(name = "COMPONENT")
 public class Component extends PanacheEntityBase implements Serializable {
 

--- a/commons/src/main/java/org/acme/model/Vulnerability.java
+++ b/commons/src/main/java/org/acme/model/Vulnerability.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.acme.common.TrimmedStringDeserializer;
 import org.acme.commonutil.VulnerabilityUtil;
 import org.acme.persistence.CollectionIntegerConverter;
@@ -50,6 +51,7 @@ import java.util.UUID;
  */
 
 @Entity
+@RegisterForReflection
 @Table(name = "VULNERABILITY")
 public class Vulnerability extends PanacheEntityBase implements Serializable {
 

--- a/commons/src/main/java/org/acme/model/VulnerabilityResult.java
+++ b/commons/src/main/java/org/acme/model/VulnerabilityResult.java
@@ -1,8 +1,11 @@
 package org.acme.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 public class VulnerabilityResult implements Serializable {
 
     private List<Vulnerability> vulnerabilities;

--- a/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReport.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReport.java
@@ -1,10 +1,12 @@
 package org.acme.client.ossindex;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ComponentReport(String coordinates, String description, String reference,
                               List<ComponentReportVulnerability> vulnerabilities) implements Serializable {

--- a/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReportRequest.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReportRequest.java
@@ -1,9 +1,11 @@
 package org.acme.client.ossindex;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.Collection;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ComponentReportRequest(Collection<String> coordinates) {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReportVulnerability.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/ossindex/ComponentReportVulnerability.java
@@ -1,10 +1,12 @@
 package org.acme.client.ossindex;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ComponentReportVulnerability(String id, String displayName, String title, String description,
                                            Float cvssScore, String cvssVector, String cwe, String cve,

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Issue.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Issue.java
@@ -2,10 +2,12 @@ package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Issue(String key, String type, String title, String description,
                     @JsonProperty("created_at") String createdAt, @JsonProperty("updated_at") String updatedAt,

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Package.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Package.java
@@ -1,9 +1,11 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Package(String type, String namespace, String name, String version, String url) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Page.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Page.java
@@ -1,10 +1,12 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Page<T>(PageMeta meta, List<PageData<T>> data) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/PageData.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/PageData.java
@@ -1,9 +1,11 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PageData<T>(String id, String type, T attributes) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/PageMeta.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/PageMeta.java
@@ -2,9 +2,11 @@ package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PageMeta(@JsonProperty("package") Package pkg) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Problem.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Problem.java
@@ -1,9 +1,11 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Problem(String id, String source, String url) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Reference.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Reference.java
@@ -1,9 +1,11 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Reference(String title, String url) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Severity.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Severity.java
@@ -1,9 +1,11 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Severity(SeveritySource source, String vector, Float score, String level) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Slots.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/Slots.java
@@ -1,10 +1,12 @@
 package org.acme.client.snyk;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.io.Serializable;
 import java.util.List;
 
+@RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Slots(List<Reference> references) implements Serializable {
 }

--- a/vulnerability-analyzer/src/main/java/org/acme/processor/retry/RetryableRecord.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/retry/RetryableRecord.java
@@ -3,6 +3,7 @@ package org.acme.processor.retry;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.processor.api.Record;
@@ -19,6 +20,7 @@ import java.util.Optional;
  * @param <K> Type of the key
  * @param <V> Type of the value
  */
+@RegisterForReflection
 public class RetryableRecord<K, V> extends Record<K, V> {
 
     private final long nextRetryAt;


### PR DESCRIPTION
Classes that are (de-)serialized with Jackson have to be explicitly registered for reflection, see https://quarkus.io/guides/writing-native-applications-tips#registering-for-reflection

Also fix `ClassNotFoundException: org.apache.commons.logging.impl.LogFactoryImpl`, see https://github.com/quarkusio/quarkus/issues/10128

Signed-off-by: nscuro <nscuro@protonmail.com>