### PR TITLE
Add health-, ready-, and liveness checks for vuln analyzer

### DIFF
--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Add various health and readiness endpoints.

The endpoints will be automatically picked up by the kubernetes and helm extensions.

### Sample Output

http://localhost:8092/q/health

```json

{
    "status": "UP",
    "checks": [
        {
            "name": "Kafka Streams state health check",
            "status": "UP",
            "data": {
                "state": "REBALANCING"
            }
        },
        {
            "name": "Database connections health check",
            "status": "UP",
            "data": {
                "<default>": "UP"
            }
        },
        {
            "name": "Kafka Streams topics health check",
            "status": "UP",
            "data": {
                "available_topics": "dtrack.vuln-analysis.component,dtrack.vuln-analysis.component.cpe,dtrack.vuln-analysis.component.purl,dtrack.vuln-analysis.component.swid,dtrack.vuln-analysis.vulnerability,dtrack.vuln-analysis.result,dtrack.vuln-analysis.info"
            }
        }
    ]
}
```

http://localhost:8092/q/health/live

```json
{
    "status": "UP",
    "checks": [
        {
            "name": "Kafka Streams state health check",
            "status": "UP",
            "data": {
                "state": "RUNNING"
            }
        }
    ]
}
```

http://localhost:8092/q/health/ready

```json
{
    "status": "UP",
    "checks": [
        {
            "name": "Database connections health check",
            "status": "UP",
            "data": {
                "<default>": "UP"
            }
        },
        {
            "name": "Kafka Streams topics health check",
            "status": "UP",
            "data": {
                "available_topics": "dtrack.vuln-analysis.component,dtrack.vuln-analysis.component.cpe,dtrack.vuln-analysis.component.purl,dtrack.vuln-analysis.component.swid,dtrack.vuln-analysis.vulnerability,dtrack.vuln-analysis.result,dtrack.vuln-analysis.info"
            }
        }
    ]
}
```