### PR TITLE
Export request duration metrics for Snyk HTTP client

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/acme/client/snyk/SnykClientConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/client/snyk/SnykClientConfiguration.java
@@ -3,6 +3,8 @@ package org.acme.client.snyk;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.httpcomponents.MicrometerHttpRequestExecutor;
 import io.micrometer.core.instrument.binder.httpcomponents.PoolingHttpClientConnectionManagerMetricsBinder;
 import org.acme.config.SnykConfig;
 import org.acme.util.RoundRobinAccessor;
@@ -14,6 +16,7 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
+import java.util.Set;
 import java.util.function.Supplier;
 
 class SnykClientConfiguration {
@@ -40,6 +43,9 @@ class SnykClientConfiguration {
                 .setDefaultRequestConfig(RequestConfig.copy(RequestConfig.DEFAULT)
                         .setConnectTimeout(3_000) // TODO: Make configurable?
                         .setSocketTimeout(3_000) // TODO: Make configurable?
+                        .build())
+                .setRequestExecutor(MicrometerHttpRequestExecutor.builder(meterRegistry)
+                        .tags(Set.of(Tag.of("client", "snykHttpClient")))
                         .build())
                 .disableAutomaticRetries() // Automatic retries are blocking
                 .build();


### PR DESCRIPTION
Example metrics:

```
httpcomponents_httpclient_request_seconds_max{client="snykHttpClient",method="GET",status="200",uri="UNKNOWN",} 0.688291934
httpcomponents_httpclient_request_seconds_count{client="snykHttpClient",method="GET",status="200",uri="UNKNOWN",} 71.0
httpcomponents_httpclient_request_seconds_sum{client="snykHttpClient",method="GET",status="200",uri="UNKNOWN",} 22.204852098
```

Note that the `uri` is always "UNKNOWN". We could add it, but there really is no point given we only ever call one endpoint of the Snyk API. And the URL would include the org ID and PURL, which would result in too many metric entries.

Signed-off-by: nscuro <nscuro@protonmail.com>