### PR TITLE
Unify metric and tag names

### DIFF
--- a/vulnerability-analyzer/src/main/java/org/acme/processor/ossindex/OssIndexProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/ossindex/OssIndexProcessor.java
@@ -3,6 +3,7 @@ package org.acme.processor.ossindex;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.core.IntervalFunction;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -62,6 +63,7 @@ public class OssIndexProcessor extends RetryingProcessor<String, Component, Stri
     private KeyValueStore<UUID, RetryableRecord<String, Component>> batchStore;
     private Cancellable batchPunctuator;
     private Gauge batchStoreEntriesGauge;
+    private DistributionSummary batchSizeDistribution;
     private Instant lastBatchAnalysis;
     
     OssIndexProcessor(final OssIndexClient client, final Cache cache, final CircuitBreaker circuitBreaker,
@@ -84,9 +86,20 @@ public class OssIndexProcessor extends RetryingProcessor<String, Component, Stri
         batchStore = context().getStateStore(batchStoreName);
         batchPunctuator = context().schedule(batchInterval, PunctuationType.WALL_CLOCK_TIME, this::punctuateBatch);
 
-        batchStoreEntriesGauge = Gauge.builder("%s.store.entries".formatted(batchStoreName), batchStore::approximateNumEntries)
-                .description("Total number of entries in the batch state store")
-                .tags(Set.of(Tag.of("taskId", context().taskId().toString())))
+        batchStoreEntriesGauge = Gauge.builder("kafka.stream.store.entries", batchStore::approximateNumEntries)
+                .description("Total number of entries in the OSS Index batch state store")
+                .tags(Set.of(
+                        Tag.of("thread_id", Thread.currentThread().getName()),
+                        Tag.of("task_id", context().taskId().toString()),
+                        Tag.of("processor", getClass().getSimpleName()),
+                        Tag.of("store", batchStoreName)
+                ))
+                .register(meterRegistry);
+        batchSizeDistribution = DistributionSummary.builder("scanner.ossindex.batch.size")
+                .tags(Set.of(
+                        Tag.of("thread_id", Thread.currentThread().getName()),
+                        Tag.of("task_id", context().taskId().toString())
+                ))
                 .register(meterRegistry);
 
         lastBatchAnalysis = Instant.now();
@@ -94,7 +107,6 @@ public class OssIndexProcessor extends RetryingProcessor<String, Component, Stri
 
     @Override
     public void process(final RetryableRecord<String, Component> record) {
-        meterRegistry.counter("ossindex.records.consumed").increment();
         addToBatch(record);
     }
 
@@ -161,6 +173,7 @@ public class OssIndexProcessor extends RetryingProcessor<String, Component, Stri
 
     private void analyzeBatch(final List<RetryableRecord<String, Component>> batch) {
         LOGGER.info("Analyzing batch of {} records", batch.size());
+        batchSizeDistribution.record(batch.size());
         lastBatchAnalysis = Instant.ofEpochMilli(context().currentSystemTimeMs());
 
         final MultivaluedMap<String, RetryableRecord<String, Component>> purlRecords = new MultivaluedHashMap<>();

--- a/vulnerability-analyzer/src/main/java/org/acme/processor/ossindex/OssIndexProcessorConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/ossindex/OssIndexProcessorConfiguration.java
@@ -32,7 +32,7 @@ class OssIndexProcessorConfiguration {
     @ApplicationScoped
     @Named("ossIndexBatchStoreBuilder")
     StoreBuilder<KeyValueStore<UUID, RetryableRecord<String, Component>>> batchStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-batch"),
+        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-batch-store"),
                 Serdes.UUID(), Serdes.serdeFrom(new ObjectMapperSerializer<>(),
                         new ObjectMapperDeserializer<>(new TypeReference<>() {
                         })));
@@ -42,7 +42,7 @@ class OssIndexProcessorConfiguration {
     @ApplicationScoped
     @Named("ossIndexRetryStoreBuilder")
     StoreBuilder<KeyValueStore<UUID, RetryableRecord<String, Component>>> retryStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-retry"),
+        return keyValueStoreBuilder(inMemoryKeyValueStore("ossindex-retry-store"),
                 Serdes.UUID(), Serdes.serdeFrom(new ObjectMapperSerializer<>(),
                         new ObjectMapperDeserializer<>(new TypeReference<>() {
                         })));

--- a/vulnerability-analyzer/src/main/java/org/acme/processor/retry/RetryingProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/retry/RetryingProcessor.java
@@ -40,12 +40,14 @@ public abstract class RetryingProcessor<KI, VI, KO, VO, KR> extends ContextualPr
 
     private KeyValueStore<KR, RetryableRecord<KI, VI>> store;
     private Cancellable punctuator;
+    private Counter recordsConsumedCounter;
     private Gauge storeEntriesGauge;
 
     /**
      * @param storeName        Name of the {@link KeyValueStore} used for retries
      * @param intervalFunction The {@link IntervalFunction} used to calculate the delay before the next retry attempt
      * @param maxAttempts      Maximum amount of retry attempts to allow
+     * @param meterRegistry    The {@link MeterRegistry} to register metrics in
      */
     protected RetryingProcessor(final String storeName, final IntervalFunction intervalFunction,
                                 final int maxAttempts, final MeterRegistry meterRegistry) {
@@ -66,9 +68,21 @@ public abstract class RetryingProcessor<KI, VI, KO, VO, KR> extends ContextualPr
         store = context().getStateStore(storeName);
         punctuator = context().schedule(Duration.ofSeconds(1), PunctuationType.WALL_CLOCK_TIME, this::punctuateRetry);
 
-        storeEntriesGauge = Gauge.builder("%s.store.entries".formatted(storeName), store::approximateNumEntries)
+        recordsConsumedCounter = Counter.builder("kafka.stream.processor.records.consumed")
+                .tags(Set.of(
+                        Tag.of("thread_id", Thread.currentThread().getName()),
+                        Tag.of("task_id", context().taskId().toString()),
+                        Tag.of("processor", getClass().getSimpleName())
+                ))
+                .register(meterRegistry);
+        storeEntriesGauge = Gauge.builder("kafka.stream.store.entries", store::approximateNumEntries)
                 .description("Total number of entries in the retry state store")
-                .tags(Set.of(Tag.of("taskId", context().taskId().toString())))
+                .tags(Set.of(
+                        Tag.of("thread_id", Thread.currentThread().getName()),
+                        Tag.of("task_id", context().taskId().toString()),
+                        Tag.of("processor", getClass().getSimpleName()),
+                        Tag.of("store", storeName)
+                ))
                 .register(meterRegistry);
     }
 
@@ -77,6 +91,8 @@ public abstract class RetryingProcessor<KI, VI, KO, VO, KR> extends ContextualPr
      */
     @Override
     public void process(final Record<KI, VI> record) {
+        recordsConsumedCounter.increment();
+
         final RetryableRecord<KI, VI> retryableRecord = store.get(retryKey(record.key(), record.value()));
         if (retryableRecord == null) {
             process(RetryableRecord.fromRecord(record));
@@ -142,12 +158,15 @@ public abstract class RetryingProcessor<KI, VI, KO, VO, KR> extends ContextualPr
      */
     protected void reportRetryStatus(final RetryableRecord<?, ?> record, final RetryStatus status) {
         final String statusText = switch (status) {
-            case SUCCEEDED -> record.retryAttempts() == 0 ? "succeededWithoutRetry" : "succeededWithRetry";
-            case FAILED -> record.retryAttempts() == 0 ? "failedWithoutRetry" : "failedWithRetry";
+            case SUCCEEDED -> record.retryAttempts() == 0 ? "succeeded_without_retry" : "succeeded_with_retry";
+            case FAILED -> record.retryAttempts() == 0 ? "failed_without_retry" : "failed_with_retry";
         };
 
-        Counter.builder("%s.retry".formatted(storeName))
+        Counter.builder("kafka.stream.processor.retries")
                 .tags(Set.of(
+                        Tag.of("thread_id", Thread.currentThread().getName()),
+                        Tag.of("task_id", context().taskId().toString()),
+                        Tag.of("processor", getClass().getSimpleName()),
                         Tag.of("status", statusText),
                         Tag.of("attempts", Integer.toString(record.retryAttempts()))
                 ))

--- a/vulnerability-analyzer/src/main/java/org/acme/processor/snyk/SnykProcessor.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/snyk/SnykProcessor.java
@@ -73,7 +73,6 @@ public class SnykProcessor extends RetryingProcessor<String, Component, String, 
 
     @Override
     public void process(final RetryableRecord<String, Component> record) {
-        meterRegistry.counter("snyk.records.consumed").increment();
         analyze(record);
     }
 

--- a/vulnerability-analyzer/src/main/java/org/acme/processor/snyk/SnykProcessorConfiguration.java
+++ b/vulnerability-analyzer/src/main/java/org/acme/processor/snyk/SnykProcessorConfiguration.java
@@ -32,7 +32,7 @@ class SnykProcessorConfiguration {
     @ApplicationScoped
     @Named("snykRetryStoreBuilder")
     StoreBuilder<KeyValueStore<UUID, RetryableRecord<String, Component>>> retryStoreBuilder() {
-        return keyValueStoreBuilder(inMemoryKeyValueStore("snyk-retry"),
+        return keyValueStoreBuilder(inMemoryKeyValueStore("snyk-retry-store"),
                 Serdes.UUID(), Serdes.serdeFrom(new ObjectMapperSerializer<>(),
                         new ObjectMapperDeserializer<>(new TypeReference<>() {
                         })));


### PR DESCRIPTION
Also enrich metrics with `thread_id` and `processor` tags, and add a new metric that will allow us to track the average size of OSS Index batches.

Signed-off-by: nscuro <nscuro@protonmail.com>