### PR TITLE
Fix load test fixture generation

### DIFF
--- a/load-tests/fixtures/generate.sh
+++ b/load-tests/fixtures/generate.sh
@@ -9,6 +9,10 @@ fi
 
 mkdir -p "$(pwd)/fixtures/generated"
 
-while read -r line < "$(pwd)/fixtures/images.txt"; do
+while read -r line; do
     trivy image -f cyclonedx -o "$(pwd)/fixtures/generated/container_$(echo "$line" | sed 's/\//_/g' | sed 's/:/_/g').cdx.json" "$line"
-done
+done < "$(pwd)/fixtures/images.txt"
+
+for file in "$(pwd)/fixtures/generated"/*.cdx.json; do
+  echo "\"$file\""
+done | jq -n '{"boms": [inputs]}' > "$(pwd)/fixtures/generated/index.json"

--- a/load-tests/fixtures/images.txt
+++ b/load-tests/fixtures/images.txt
@@ -45,8 +45,8 @@ nextcloud:25.0.2
 owasp/zap2docker-stable:2.10.0
 owasp/zap2docker-stable:2.12.0
 owasp/zap2docker-stable:2.8.0
-quay.io/coreos/etcd:v3.0.17
-quay.io/coreos/etcd:v3.3.3
+quay.io/coreos/etcd:v3.2.32
+quay.io/coreos/etcd:v3.3.20
 quay.io/coreos/etcd:v3.5.5
 quay.io/keycloak/keycloak:18.0
 quay.io/keycloak/keycloak:19.0


### PR DESCRIPTION
Some etcd image versions used manifests that are incompatible with the container library that trivy uses. The `images.txt` list wasn't correctly iterated over by `generate.sh`. The `vuln-analyzer` test script has been updated to use the generated fixtures.

Signed-off-by: nscuro <nscuro@protonmail.com>