### PR TITLE
Fix Maven repo meta analysis failing with native image

### DIFF
--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -39,12 +39,14 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-kafka-streams</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jaxb</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-apache-httpclient</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
@@ -69,7 +71,6 @@
       <artifactId>kafka-streams-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>


### PR DESCRIPTION
When running the repository meta analyzer as native images, it would fail to analyze Maven components with the following stacktrace:

```
java.util.MissingResourceException: Could not load any resource bundle by com.sun.org.apache.xml.internal.res.XMLErrorResources
	at java.xml@17.0.5/jdk.xml.internal.SecuritySupport.lambda$getResourceBundle$5(SecuritySupport.java:280)
	at java.base@17.0.5/java.security.AccessController.executePrivileged(AccessController.java:168)
	at java.base@17.0.5/java.security.AccessController.doPrivileged(AccessController.java:318)
	at java.xml@17.0.5/jdk.xml.internal.SecuritySupport.getResourceBundle(SecuritySupport.java:273)
	at java.xml@17.0.5/jdk.xml.internal.SecuritySupport.getResourceBundle(SecuritySupport.java:262)
	at java.xml@17.0.5/com.sun.org.apache.xml.internal.res.XMLMessages.createXMLMessage(XMLMessages.java:84)
	at java.xml@17.0.5/com.sun.org.apache.xml.internal.utils.ObjectPool.getInstance(ObjectPool.java:144)
	at java.xml@17.0.5/com.sun.org.apache.xml.internal.utils.StringBufferPool.get(StringBufferPool.java:45)
	at java.xml@17.0.5/com.sun.org.apache.xml.internal.dtm.ref.dom2dtm.DOM2DTM.getStringValue(DOM2DTM.java:822)
	at java.xml@17.0.5/com.sun.org.apache.xpath.internal.objects.XNodeSet.getStringFromNode(XNodeSet.java:219)
	at java.xml@17.0.5/com.sun.org.apache.xpath.internal.objects.XNodeSet.str(XNodeSet.java:282)
	at java.xml@17.0.5/com.sun.org.apache.xpath.internal.jaxp.XPathImplUtil.getResultAsType(XPathImplUtil.java:151)
	at java.xml@17.0.5/com.sun.org.apache.xpath.internal.jaxp.XPathExpressionImpl.eval(XPathExpressionImpl.java:81)
	at java.xml@17.0.5/com.sun.org.apache.xpath.internal.jaxp.XPathExpressionImpl.evaluate(XPathExpressionImpl.java:89)
	at org.acme.repositories.MavenMetaAnalyzer.analyze(MavenMetaAnalyzer.java:96)
	at org.acme.repositories.MavenMetaAnalyzer_ClientProxy.analyze(Unknown Source)
```

The necessary resource bundles are defined in `quarkus-jaxb`. Including `quarkus-jaxb` as dependency resolves the issue, and analysis is taking place as expected.

https://github.com/quarkusio/quarkus/blob/2.15.3.Final/extensions/jaxp/deployment/src/main/java/io/quarkus/jaxp/deployment/JaxpProcessor.java#L38