### PR TITLE
Cleanup dependency management

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-apache-httpclient</artifactId>
-      <version>2.15.3.Final</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>
@@ -87,11 +86,6 @@
     <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.github.resilience4j</groupId>
-      <artifactId>resilience4j-circuitbreaker</artifactId>
-      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/mirror-service/pom.xml
+++ b/mirror-service/pom.xml
@@ -18,6 +18,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
         <dependency>
@@ -47,13 +51,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
-            <version>2.36.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -62,19 +64,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>2.38</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20220924</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/notification-publisher/pom.xml
+++ b/notification-publisher/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>io.quarkiverse.helm</groupId>
       <artifactId>quarkus-helm</artifactId>
-      <version>0.2.3</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,15 +25,15 @@
 
     <!-- Dependency Versions -->
     <lib.assertj.version>3.24.2</lib.assertj.version>
-    <lib.caffeine.version>3.1.2</lib.caffeine.version>
     <lib.cpe-parser.version>2.0.2</lib.cpe-parser.version>
     <lib.cvss-calculator.version>1.4.1</lib.cvss-calculator.version>
     <lib.cyclonedx-java.version>7.3.1</lib.cyclonedx-java.version>
     <lib.json-unit.version>2.36.0</lib.json-unit.version>
     <lib.maven-artifact.version>4.0.0-alpha-3</lib.maven-artifact.version>
     <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
-    <lib.packageurl-java.version>1.4.1</lib.packageurl-java.version>
+    <lib.org-json.version>20220924</lib.org-json.version>
     <lib.pebble.version>3.1.6</lib.pebble.version>
+    <lib.quarkus-helm.version>0.2.3</lib.quarkus-helm.version>
     <lib.resilience4j.version>2.0.2</lib.resilience4j.version>
     <lib.wiremock.version>2.35.0</lib.wiremock.version>
     <lib.xercesimpl.version>2.12.2</lib.xercesimpl.version>
@@ -88,30 +88,26 @@
       </dependency>
       <dependency>
         <groupId>io.github.resilience4j</groupId>
-        <artifactId>resilience4j-cache</artifactId>
-        <version>${lib.resilience4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.resilience4j</groupId>
         <artifactId>resilience4j-micrometer</artifactId>
-        <version>${lib.resilience4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.resilience4j</groupId>
-        <artifactId>resilience4j-ratelimiter</artifactId>
         <version>${lib.resilience4j.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>com.github.ben-manes.caffeine</groupId>
-        <artifactId>jcache</artifactId>
-        <version>${lib.caffeine.version}</version>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>${lib.org-json.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.pebbletemplates</groupId>
         <artifactId>pebble</artifactId>
         <version>${lib.pebble.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.quarkiverse.helm</groupId>
+        <artifactId>quarkus-helm</artifactId>
+        <version>${lib.quarkus-helm.version}</version>
       </dependency>
 
       <dependency>
@@ -124,12 +120,6 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${lib.maven-artifact.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.github.package-url</groupId>
-        <artifactId>packageurl-java</artifactId>
-        <version>${lib.packageurl-java.version}</version>
       </dependency>
 
       <dependency>

--- a/repository-meta-analyzer/pom.xml
+++ b/repository-meta-analyzer/pom.xml
@@ -84,7 +84,6 @@
     <dependency>
       <groupId>io.quarkiverse.helm</groupId>
       <artifactId>quarkus-helm</artifactId>
-      <version>0.2.3</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -97,7 +96,6 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20220924</version>
     </dependency>
 
   </dependencies>

--- a/vulnerability-analyzer/pom.xml
+++ b/vulnerability-analyzer/pom.xml
@@ -101,12 +101,10 @@
         <dependency>
             <groupId>us.springett</groupId>
             <artifactId>cpe-parser</artifactId>
-            <version>${lib.cpe-parser.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.helm</groupId>
             <artifactId>quarkus-helm</artifactId>
-            <version>0.2.3</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
* Define versions of dependencies that are not provided by Quarkus in the parent `pom.xml`. Avoids Renovate raising multiple PRs for the same dependency.
* Remove dependency declarations that are no longer used, or brought in transitively already.
* Replace dependencies on `jersey-common` with the Quarkus-native `quarkus-resteasy`.

Signed-off-by: nscuro <nscuro@protonmail.com>