### PR TITLE
Use pre-built API server container image for demo

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -8,45 +8,39 @@ A UNIX-based system is strongly recommended. In case you're bound to Windows, pl
 > **Note**
 > A >4 core CPU and >=16GB RAM are recommended for a smooth experience.
 
-1. Start by creating a new directory for this setup:
+1. In a terminal, clone *this* repository and navigate to it:
 ```shell
-mkdir demo
-```
-2. Clone both *this* repository and that of our [modified Dependency-Track API server] into the directory you just created:
-```shell
-cd demo
 git clone https://github.com/mehab/DTKafkaPOC.git
-git clone --branch kafka-poc https://github.com/sahibamittal/dependency-track.git
+cd DTKafkaPOC
 ```
-  * Alternatively, should you not have Git installed, you can download the repositories [here](https://github.com/mehab/DTKafkaPOC/archive/refs/heads/main.zip)
-    and [here](https://github.com/sahibamittal/dependency-track/archive/refs/heads/kafka-poc.zip)
-3. Generate a secret key used for encryption and decryption of credentials in the database:
+2. Generate a secret key for encryption and decryption of credentials in the database:
 ```shell
 openssl rand 32 > secret.key
 ```
-4. Pull and build all required container images, and finally start them:
+3. Pull and start all containers:
 ```shell
-cd DTKafkaPOC
-docker compose --profile demo pull
-docker compose --profile demo build
-docker compose --profile demo up -d
+docker compose --profile demo up -d --pull always
 ```
   * Make sure you include the `--profile demo` flag!
-  * Building and the images may take a few minutes
 
 Once completed, the following services will be available:
 
-| Service                     | URL                    |
-|:----------------------------|:-----------------------|
-| Dependency-Track API Server | http://localhost:8080  |
-| Dependency-Track Frontend   | http://localhost:8081  |
-| Redpanda Console            | http://localhost:28080 |
-| PostgreSQL                  | `localhost:5432`       |
-| Redpanda Kafka API          | `localhost:9092`       |
+| Service                                | URL                    |
+|:---------------------------------------|:-----------------------|
+| Dependency-Track API Server + Frontend | http://localhost:8080  |
+| Redpanda Console                       | http://localhost:28080 |
+| PostgreSQL                             | `localhost:5432`       |
+| Redpanda Kafka API                     | `localhost:9092`       |
 
 > **Note**  
 > You'll not need to interact with PostgreSQL or the Kafka API directly to try out the PoC,
 > but if you're curious 🕵️ of course you can!
+
+Finally, to remove everything again, including persistent volumes:
+
+```shell
+docker compose --profile demo down --volumes
+```
 
 ### Common Issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,14 +85,16 @@ services:
     restart: unless-stopped
 
   apiserver:
-    build:
-      context: ../dependency-track
-      dockerfile: src/main/docker/Dockerfile.demo
+    image: ghcr.io/sahibamittal/dependency-track-bundled:snapshot
     container_name: dt-apiserver
     depends_on:
       - postgres
       - redpanda
     environment:
+      # Limit maximum heap size to 4GB.
+      # Default would be 90% of available memory,
+      # which can cause problems on some workstations.
+      EXTRA_JAVA_OPTS: "-Xmx4g"
       ALPINE_DATABASE_MODE: "external"
       ALPINE_DATABASE_URL: "jdbc:postgresql://dt-postgres:5432/dtrack"
       ALPINE_DATABASE_DRIVER: "org.postgresql.Driver"
@@ -106,16 +108,6 @@ services:
     volumes:
       - "apiserver-data:/data"
       - "./secret.key:/var/run/secrets/secret.key:ro"
-    profiles:
-      - demo
-    restart: unless-stopped
-
-  frontend:
-    image: dependencytrack/frontend:snapshot
-    environment:
-      API_BASE_URL: "http://localhost:8080"
-    ports:
-      - "127.0.0.1:8081:8080"
     profiles:
       - demo
     restart: unless-stopped


### PR DESCRIPTION
Also limit max heap size of the container to 4GB, instead of allowing it to claim up to 90% of available RAM.

Signed-off-by: nscuro <nscuro@protonmail.com>